### PR TITLE
preliminary openbsd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Supported Platforms
 * RHEL 6
 * Ubuntu 14.04 lts
 * FreeBSD 10
+* OpenBSD 6.0
 
 It will likely run on other platforms, just drop in vars/ a new file to support your os variant, vars are parsed in the following order/format:
 * {{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml
@@ -20,6 +21,7 @@ Requirements
 ------------
 
 * For FreeBSD a working pkgng setup is required (see: https://www.freebsd.org/doc/handbook/pkgng-intro.html )
+* For OpenBSD, you must have PKG_PATH or installpath in `/etc/pkg.conf` set. (see: https://www.openbsd.org/faq/faq15.html#Easy )
 
 
 Role Variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ default_owner: root
 default_group: root
 postfix_user: postfix
 postfix_group: postfix
+setgid_group: postdrop
 postfix_master_template: master.cf.j2
 postfix_main_template: main.cf.j2
 postfix_whitelist_template: recipient_domains.j2
@@ -13,6 +14,10 @@ postfix_main:
   - myhostname = {{ ansible_hostname }}
   - mydomain = {{ ansible_domain }}
   - myorigin = {{ ansible_hostname }}
+  - mail_owner = {{ mail_owner }}
+  - setgid_group = {{ setgid_group }}
+  - daemon_directory = {{ daemon_directory }}
+  - command_directory = {{ command_directory }}
   - inet_interfaces = localhost
   - inet_protocols = all
   - mydestination = localhost.localdomain, localhost, localdomain

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,14 +12,7 @@
    - "{{ ansible_os_family }}.yml"
    - default.yml
 
-- include: main_redhat.yml
-  when: ansible_os_family == 'RedHat'
-
-- include: main_debian.yml
-  when: ansible_os_family == 'Debian'
-
-- include: main_freebsd.yml
-  when: ansible_os_family == 'FreeBSD'
+- include: "main_{{ ansible_os_family | lower }}.yml"
 
 - name: generate main.cf
   tags:

--- a/tasks/main_openbsd.yml
+++ b/tasks/main_openbsd.yml
@@ -1,0 +1,16 @@
+# OpenBSD related tasks
+---
+- name: Disable OpenSMTPd
+  tags:
+    - postfix
+  service:
+    name: smtpd
+    enabled: no
+    state: stopped
+
+- name: install packages for OpenBSD
+  tags:
+    - postfix
+    - packages
+  openbsd_pkg: name={{item}} state=present
+  with_items: "{{ postfix_package_names }}"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -9,6 +9,7 @@ command_directory: /usr/local/sbin
 daemon_directory: /usr/local/libexec/postfix
 data_directory: /var/db/postfix
 mail_owner: postfix
+setgid_group: maildrop
 sendmail_path: /usr/local/sbin/sendmail
 newaliases_path: /usr/local/bin/newaliases
 mailq_path: /usr/local/bin/mailq

--- a/vars/OpenBSD.yml
+++ b/vars/OpenBSD.yml
@@ -1,0 +1,16 @@
+# OpenBSD Family OS defaults
+---
+default_group: wheel
+postfix_config_directory: /etc/postfix
+postfix_package_names: postfix--sasl2%stable
+postfix_service_name: postfix
+queue_directory: /var/spool/postfix
+command_directory: /usr/local/sbin
+daemon_directory: /usr/local/libexec/postfix
+data_directory: /var/db/postfix
+mail_owner: _postfix
+setgid_group: _postdrop
+sendmail_path: /usr/sbin/sendmail
+newaliases_path: /usr/bin/newaliases
+mailq_path: /usr/bin/mailq
+postfix_os_supported: yes


### PR DESCRIPTION
First time contributing to an ansible module, so I hope this is good enough work.

I've tested by changes on:

* CentOS6
* CentOS7
* FreeBSD 11
* OpenBSD 6.0

Only thing a little different is that OpenSMTPd (the default MTA on OpenBSD) has to be disabled.